### PR TITLE
XPath query in config.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 branches:
   only:
   - master
+  - dev
+  - pr9
   - /^v.*$/
 language: python
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ TO DO: A true quick start example, just SRA data?
 
 ### Added
 - NCBImetaUtilties.py function: adv_xml_search to allow pre-formatted XPath query (PR #9)
+- Two new error classes ErrorXPathQueryMultiElement and ErrorXPathElementUnknown
 
 ### Changed
 - Bug: Improved specificty of SRABioSampleAccession and SRABioProjectAccession

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,19 @@ and this project "attempts" to adhere to [Semantic Versioning](http://semver.org
 ## [Development]
 
 TO DO: A true quick start example, just SRA data?
-Fix BioSampleBioProjectAccession, NucleotideAssemblyAccesion?
 
-## [v0.6.5] - 2020-0227
+## [v0.6.5] - 2020-0304
 
 ### Added
-- NCBImetaUtilties.py function: adv_xml_search to allow pre-formatted XPATH query
+- NCBImetaUtilties.py function: adv_xml_search to allow pre-formatted XPath query (PR #9)
 
 ### Changed
 - Bug: Improved specificty of SRABioSampleAccession and SRABioProjectAccession
-- NucleotideBioSampleAccession now a preformatted XPATH query (previously empty value)
+- NucleotideBioSampleAccession now a preformatted XPath query (previously empty value)
+- BioSampleBioProjectAccession now a preformatted XPath query (previously non-specific)
 
 ### Removed
-- Non-specific node NucleotideAssemblyAccession 
+- Non-specific node NucleotideAssemblyAccession
 
 ## [v0.6.4] - 2020-0220 - Bobby Tables
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project "attempts" to adhere to [Semantic Versioning](http://semver.org
 
 TO DO: A true quick start example, just SRA data?
 
+## [v0.6.5] - 2020-0227
+
+### Changed
+- Made SRABioSampleAccession a specific match by including SAMPLE_DESCRIPTOR in path
+
 ## [v0.6.4] - 2020-0220 - Bobby Tables
 
 ### Added
@@ -219,7 +224,9 @@ Jumps directly from v0.5.0 to v0.6.0 because changes are significant enough to b
 - Repository migrated from GenomeCollector
 
 [Development]: https://github.com/ktmeaton/NCBImeta/compare/HEAD...dev
-[v0.6.2]: https://github.com/ktmeaton/NCBImeta/compare/v0.6.2...HEAD
+[v0.6.4]: https://github.com/ktmeaton/NCBImeta/compare/v0.6.4...HEAD
+[v0.6.3]: https://github.com/ktmeaton/NCBImeta/compare/v0.6.3...v0.6.4
+[v0.6.2]: https://github.com/ktmeaton/NCBImeta/compare/v0.6.2...v0.6.3
 [v0.6.1]: https://github.com/ktmeaton/NCBImeta/compare/v0.6.1...v0.6.2
 [v0.6.0]: https://github.com/ktmeaton/NCBImeta/compare/v0.6.0...v0.6.1
 [v0.5.0]: https://github.com/ktmeaton/NCBImeta/compare/v0.5.0...v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,15 @@ Fix BioSampleBioProjectAccession, NucleotideAssemblyAccesion?
 
 ## [v0.6.5] - 2020-0227
 
+### Added
+- NCBImetaUtilties.py function: adv_xml_search to allow pre-formatted XPATH query
+
 ### Changed
 - Bug: Improved specificty of SRABioSampleAccession and SRABioProjectAccession
+- NucleotideBioSampleAccession now a preformatted XPATH query (previously empty value)
+
+### Removed
+- Non-specific node NucleotideAssemblyAccession 
 
 ## [v0.6.4] - 2020-0220 - Bobby Tables
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project "attempts" to adhere to [Semantic Versioning](http://semver.org
 ## [Development]
 
 TO DO: A true quick start example, just SRA data?
+Fix BioSampleBioProjectAccession, NucleotideAssemblyAccesion?
 
 ## [v0.6.5] - 2020-0227
 
 ### Changed
-- Made SRABioSampleAccession a specific match by including SAMPLE_DESCRIPTOR in path
+- Bug: Improved specificty of SRABioSampleAccession and SRABioProjectAccession
 
 ## [v0.6.4] - 2020-0220 - Bobby Tables
 

--- a/contrib.md
+++ b/contrib.md
@@ -1,0 +1,18 @@
+# CONTRIBUTING
+
+## Pull Requests
+
+### Merging Pull Requests
+Fetch the PR's pseudo-branch
+```
+git fetch origin pull/9/head:pr9
+```
+Switch to that branch
+```
+git checkout pr9
+```
+Pull upstream dev that has occurred
+```
+git pull origin dev
+```
+Perform all necessary testing and CI

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -186,7 +186,7 @@ TABLE_COLUMNS :
 
   - SRA :
     - SRABioProjectAccession : EXTERNAL_ID, namespace, BioProject
-    - SRABioSampleAccession : EXTERNAL_ID, namespace, BioSample
+    - SRABioSampleAccession : SAMPLE_DESCRIPTION, EXTERNAL_ID, namespace, BioSample
     - SRASampleAccession : SAMPLE_DESCRIPTOR, accession
     - SRASampleName : SAMPLE, alias
     - SRAExperimentAccession : EXPERIMENT, accession

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -185,7 +185,7 @@ TABLE_COLUMNS :
     - NucleotideComment : NullValue
 
   - SRA :
-    - SRABioProjectAccession : EXTERNAL_ID, namespace, BioProject
+    - SRABioProjectAccession : STUDY_REF, EXTERNAL_ID, namespace, BioProject
     - SRABioSampleAccession : SAMPLE_DESCRIPTION, EXTERNAL_ID, namespace, BioSample
     - SRASampleAccession : SAMPLE_DESCRIPTOR, accession
     - SRASampleName : SAMPLE, alias

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -69,7 +69,7 @@ TABLE_COLUMNS :
   - BioSample :
     - BioSampleAccession: BioSample, accession
     - BioSampleAccessionSecondary: NullValue
-    - BioSampleBioProjectAccession: Link, label
+    - BioSampleBioProjectAccession: XPATH, //Links/Link[@target='bioproject']/@label
     - BioSampleSRAAccession: Id, db, SRA
     - BioSampleTitle: Title
     - BioSampleName: Id, db_label, Sample name

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -128,9 +128,8 @@ TABLE_COLUMNS :
   - Nucleotide :
     - NucleotideAccession : GBSeq_primary-accession
     - NucleotideAccessionVersion : GBSeq_accession-version
-    - NucleotideBioSampleAccession: NucleotideBioSample
+    - NucleotideBioSampleAccession: XPATH, //User-field_data_strs_E[../../../User-field_label/Object-id/Object-id_str/text() = 'BioSample']
     - NucleotideBioProjectAccession : GBSeq_project
-    - NucleotideAssemblyAccession : GBSeq_xrefs, GBXref_id
     - NucleotideOrganism : GBSeq_organism
     - NucleotideTaxonomy : GBSeq_taxonomy
     - NucleotideDefinition : GBSeq_definition

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -128,7 +128,7 @@ TABLE_COLUMNS :
   - Nucleotide :
     - NucleotideAccession : GBSeq_primary-accession
     - NucleotideAccessionVersion : GBSeq_accession-version
-    - NucleotideBioSampleAccession: XPATH, //User-field_data_strs_E[../../../User-field_label/Object-id/Object-id_str/text() = 'BioSample']
+    - NucleotideBioSampleAccession: XPATH, //GBXref[GBXref_dbname/text() = 'BioSample']/GBXref_id
     - NucleotideBioProjectAccession : GBSeq_project
     - NucleotideOrganism : GBSeq_organism
     - NucleotideTaxonomy : GBSeq_taxonomy

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -185,8 +185,8 @@ TABLE_COLUMNS :
     - NucleotideComment : NullValue
 
   - SRA :
-    - SRABioProjectAccession : STUDY_REF, EXTERNAL_ID, namespace, BioProject
-    - SRABioSampleAccession : SAMPLE_DESCRIPTOR, EXTERNAL_ID, namespace, BioSample
+    - SRABioProjectAccession : STUDY, EXTERNAL_ID, namespace, BioProject
+    - SRABioSampleAccession : RUN_SET, RUN, Pool, EXTERNAL_ID, namespace, BioSample
     - SRASampleAccession : SAMPLE_DESCRIPTOR, accession
     - SRASampleName : SAMPLE, alias
     - SRAExperimentAccession : EXPERIMENT, accession

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -186,7 +186,7 @@ TABLE_COLUMNS :
 
   - SRA :
     - SRABioProjectAccession : STUDY_REF, EXTERNAL_ID, namespace, BioProject
-    - SRABioSampleAccession : SAMPLE_DESCRIPTION, EXTERNAL_ID, namespace, BioSample
+    - SRABioSampleAccession : SAMPLE_DESCRIPTOR, EXTERNAL_ID, namespace, BioSample
     - SRASampleAccession : SAMPLE_DESCRIPTOR, accession
     - SRASampleName : SAMPLE, alias
     - SRAExperimentAccession : EXPERIMENT, accession

--- a/ncbimeta/NCBImeta.py
+++ b/ncbimeta/NCBImeta.py
@@ -389,8 +389,6 @@ def UpdateDB(table, output_dir, database, email, search_term, table_columns, log
             if column_payload[0] == "XPATH":
                 column_payload.remove("XPATH")
                 column_payload_xpath = column_payload[0]
-                print(column_payload_xpath)
-                print(etree.tostring(working_root).decode())
                 NCBImetaUtilities.adv_xml_search(working_root, column_payload_xpath, column_name, column_dict)
             else:
                 # If there are special character, this query should not be used for xpath!!

--- a/ncbimeta/NCBImeta.py
+++ b/ncbimeta/NCBImeta.py
@@ -388,7 +388,10 @@ def UpdateDB(table, output_dir, database, email, search_term, table_columns, log
 
             if column_payload[0] == "XPATH":
                 column_payload.remove("XPATH")
-                NCBImetaUtilities.adv_xml_search(working_root, column_payload, column_name, column_dict)
+                column_payload_xpath = column_payload[0]
+                print(column_payload_xpath)
+                print(etree.tostring(working_root).decode())
+                NCBImetaUtilities.adv_xml_search(working_root, column_payload_xpath, column_name, column_dict)
             else:
                 # If there are special character, this query should not be used for xpath!!
                 bool_special_char = False
@@ -399,7 +402,7 @@ def UpdateDB(table, output_dir, database, email, search_term, table_columns, log
                 # If no special characters, run xpath search Functions
                 if not bool_special_char:
                     NCBImetaUtilities.xml_search(working_root, column_payload, column_payload[0], column_name, column_dict)
-     
+
             # Special parsing for GBSeq_comment
             # If we're on the GBSeq_comment element and the comment was added to the dictionary
             if "GBSeq_comment" in column_payload and len(column_dict[column_name]) > 0:

--- a/ncbimeta/NCBImetaErrors.py
+++ b/ncbimeta/NCBImetaErrors.py
@@ -173,3 +173,29 @@ class ErrorSQLNameSanitize(Exception):
     def __str__(self):
         '''When the error is raised, print the name and the recommended sanitized version.'''
         return ("\n\nThe name: " + self.value + " contains problematic characters. Please rename it to: " + self.sanitize_value )
+
+class ErrorXPathQueryMultiElement(Exception):
+    def __init__(self, value):
+        '''
+        The constructor for ErrorXPathQueryMultiElement class.
+
+        Parameters:
+        value (str): The Xpath query.
+        '''
+        self.value = value
+    def __str__(self):
+        '''When the error is raised, print the problematic Xpath query.'''
+        return ("\n\nMore than one element returned for XPath {}. Are you using the correct XPath query?".format(self.value))
+
+class ErrorXPathElementUnknown(Exception):
+    def __init__(self, value):
+        '''
+        The constructor for ErrorXPathElementUnknown class.
+
+        Parameters:
+        value (str): The returned search result from an Xpath query.
+        '''
+        self.value = value
+    def __str__(self):
+        '''When the error is raised, print the problematic search result.'''
+        return ("\n\nUnknown XPath return element: {}".format(type(self.value)))

--- a/ncbimeta/NCBImetaUtilities.py
+++ b/ncbimeta/NCBImetaUtilities.py
@@ -47,6 +47,7 @@ def table_exists(db_cur, table_name):
 def adv_xml_search(xml_root, targ_xpath, column_name, xml_dict):
     '''
     Search xml_root using targ_xpath XPATH query, assign to column name in xml_dict.
+    Contributor: @hellothisisMatt
 
     Parameters:
     xml_root (ElementTree): xml document as etree object

--- a/ncbimeta/NCBImetaUtilities.py
+++ b/ncbimeta/NCBImetaUtilities.py
@@ -44,8 +44,19 @@ def table_exists(db_cur, table_name):
     query = "SELECT name FROM sqlite_master WHERE type='table' AND name='{}'".format(table_name)
     return db_cur.execute(query).fetchone() is not None
 
-def adv_xml_search(xml_root, xpath, column_name, xml_dict):
-    targ_xpath = ".//{}".format("/".join(xpath))
+def adv_xml_search(xml_root, targ_xpath, column_name, xml_dict):
+    '''
+    Search xml_root using targ_xpath XPATH query, assign to column name in xml_dict.
+
+    Parameters:
+    xml_root (ElementTree): xml document as etree object
+    targ_xpath (str): XPATH query (lxml python module, XPATH 1.0)
+    column_name (str): column_name in xml_dict to assign node value to.
+    xml_dict (dict): A dictionary to modify and store found values.
+
+    Returns:
+    Void. Instead the function mutates the dictionary xml_dict.
+    '''
     results = xml_root.xpath(targ_xpath)
     for result in results:
         if result.text:
@@ -53,10 +64,10 @@ def adv_xml_search(xml_root, xpath, column_name, xml_dict):
             xml_dict[column_name].append(str(result_text))
         elif len(result) > 0:
             xml_dict[column_name].append(result.tag)
-    
+
 def xml_search(xml_root, search_list, current_tag, column_name, xml_dict):
     '''
-    Search xml_root using XPATH for nodes, attributes in search_list and update node_dict.
+    Search xml_root using XPATH for nodes, attributes in search_list and assign to column_name in xml_dict.
     In addition to searching, this function also handles escaped XML as text &lt; and &gt;
     characters, as well as CDATA sections.
 
@@ -64,6 +75,7 @@ def xml_search(xml_root, search_list, current_tag, column_name, xml_dict):
     xml_root (ElementTree): xml document as etree object
     search_list (list): list of nodes and attributes in descending hierarchy
     current_tag (str): current tag (or attribute/value) to be searching
+    column_name (str): column_name in xml_dict to assign node value to.
     xml_dict (dict): A dictionary to modify and store found values.
 
     Returns:

--- a/ncbimeta/NCBImetaUtilities.py
+++ b/ncbimeta/NCBImetaUtilities.py
@@ -47,7 +47,7 @@ def table_exists(db_cur, table_name):
 def adv_xml_search(xml_root, targ_xpath, column_name, xml_dict):
     '''
     Search xml_root using targ_xpath XPATH query, assign to column name in xml_dict.
-    Contributor: @hellothisisMatt
+    Contributor: @hellothisisMatt, Edited: @ktmeaton
 
     Parameters:
     xml_root (ElementTree): xml document as etree object
@@ -59,12 +59,22 @@ def adv_xml_search(xml_root, targ_xpath, column_name, xml_dict):
     Void. Instead the function mutates the dictionary xml_dict.
     '''
     results = xml_root.xpath(targ_xpath)
+    # Figure out if result node is text, tag, or attribute
+    # There are possibly more edge cases, an error will be thrown
     for result in results:
-        if result.text:
+        try:
+            # Test for a text result (fail if attr or tag)
             result_text = result.text.strip()
-            xml_dict[column_name].append(str(result_text))
-        elif len(result) > 0:
-            xml_dict[column_name].append(result.tag)
+        except AttributeError:
+            try:
+                # Test for a tag result (fail if attr)
+                result_text = result.tag.strip()
+            except AttributeError:
+                # Last chance, attr result
+                result_text = result.strip()
+
+        # Add the found node value to the dictionary
+        xml_dict[column_name].append(str(result_text))
 
 def xml_search(xml_root, search_list, current_tag, column_name, xml_dict):
     '''

--- a/schema/Nucleotide.yaml
+++ b/schema/Nucleotide.yaml
@@ -13,7 +13,7 @@
 # Accession Numbers and ID
     - NucleotideAccession : GBSeq_primary-accession
     - NucleotideAccessionVersion : GBSeq_accession-version
-    - NucleotideBioSampleAccession: XPATH, //User-field_data_strs_E[../../../User-field_label/Object-id/Object-id_str/text() = 'BioSample']
+    - NucleotideBioSampleAccession: XPATH, //GBXref[GBXref_dbname/text() = 'BioSample']/GBXref_id
     - NucleotideBioProjectAccession : GBSeq_project
 
 # Taxonomy Information

--- a/schema/Nucleotide.yaml
+++ b/schema/Nucleotide.yaml
@@ -13,9 +13,8 @@
 # Accession Numbers and ID
     - NucleotideAccession : GBSeq_primary-accession
     - NucleotideAccessionVersion : GBSeq_accession-version
-    - NucleotideBioSampleAccession: NucleotideBioSample
+    - NucleotideBioSampleAccession: XPATH, //User-field_data_strs_E[../../../User-field_label/Object-id/Object-id_str/text() = 'BioSample']
     - NucleotideBioProjectAccession : GBSeq_project
-    - NucleotideAssemblyAccession : GBSeq_xrefs, GBXref_id
 
 # Taxonomy Information
     - NucleotideOrganism : GBSeq_organism

--- a/schema/README_schema.md
+++ b/schema/README_schema.md
@@ -45,6 +45,9 @@ The value in this case, is a list of 2 elements:
 The first value ("Experiment"), is the name of the node.
 The second value ("accession") is the attribute to target.    
 
+Note that the list of elements are values separated by a comma and a single space.  
+This is mandatory and used for parsing/splitting them into separate elements.
+
 ## 3) Retrieving a simple node value by specifying an attribute value.
 
 User selects:

--- a/schema/SRA.yaml
+++ b/schema/SRA.yaml
@@ -7,7 +7,7 @@
 
 # Accession Numbers and ID
     - SRABioProjectAccession : STUDY_REF, EXTERNAL_ID, namespace, BioProject
-    - SRABioSampleAccession : SAMPLE_DESCRIPTION, EXTERNAL_ID, namespace, BioSample
+    - SRABioSampleAccession : SAMPLE_DESCRIPTOR, EXTERNAL_ID, namespace, BioSample
     - SRASampleAccession : SAMPLE_DESCRIPTOR, accession
     - SRAExperimentAccession : EXPERIMENT, accession
     - SRARunAccession : RUN, accession

--- a/schema/SRA.yaml
+++ b/schema/SRA.yaml
@@ -7,7 +7,7 @@
 
 # Accession Numbers and ID
     - SRABioProjectAccession : EXTERNAL_ID, namespace, BioProject
-    - SRABioSampleAccession : EXTERNAL_ID, namespace, BioSample
+    - SRABioSampleAccession : SAMPLE_DESCRIPTION, EXTERNAL_ID, namespace, BioSample
     - SRASampleAccession : SAMPLE_DESCRIPTOR, accession
     - SRAExperimentAccession : EXPERIMENT, accession
     - SRARunAccession : RUN, accession

--- a/schema/SRA.yaml
+++ b/schema/SRA.yaml
@@ -6,7 +6,7 @@
 #     (genome OR genomes OR genomic OR genomics) NOT transcriptomic[Source]
 
 # Accession Numbers and ID
-    - SRABioProjectAccession : EXTERNAL_ID, namespace, BioProject
+    - SRABioProjectAccession : STUDY_REF, EXTERNAL_ID, namespace, BioProject
     - SRABioSampleAccession : SAMPLE_DESCRIPTION, EXTERNAL_ID, namespace, BioSample
     - SRASampleAccession : SAMPLE_DESCRIPTOR, accession
     - SRAExperimentAccession : EXPERIMENT, accession

--- a/schema/SRA.yaml
+++ b/schema/SRA.yaml
@@ -6,8 +6,8 @@
 #     (genome OR genomes OR genomic OR genomics) NOT transcriptomic[Source]
 
 # Accession Numbers and ID
-    - SRABioProjectAccession : STUDY_REF, EXTERNAL_ID, namespace, BioProject
-    - SRABioSampleAccession : SAMPLE_DESCRIPTOR, EXTERNAL_ID, namespace, BioSample
+    - SRABioProjectAccession : STUDY, EXTERNAL_ID, namespace, BioProject
+    - SRABioSampleAccession : RUN_SET, RUN, Pool, EXTERNAL_ID, namespace, BioSample
     - SRASampleAccession : SAMPLE_DESCRIPTOR, accession
     - SRAExperimentAccession : EXPERIMENT, accession
     - SRARunAccession : RUN, accession

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -147,3 +147,23 @@ def test_ErrorSQLNameSanitize():
     error_output = str(test_error)
     error_expect =  ("\n\nThe name: " + test_name + " contains problematic characters. Please rename it to: " + test_sanitize_name )
     assert error_output == error_expect
+
+def test_ErrorXPathQueryMultiElement():
+    '''Test the class ErrorXPathQueryMultiElement (error when bad multiple matches have been found for an Xpath query)'''
+    # Use an improper table name
+    test_xpath = "//RUN"
+    # Raise the error
+    test_error = NCBImetaErrors.ErrorXPathQueryMultiElement(test_xpath)
+    error_output = str(test_error)
+    error_expect =  ("\n\nMore than one element returned for XPath {}. Are you using the correct XPath query?".format(test_xpath))
+    assert error_output == error_expect
+
+def test_ErrorXPathElementUnknown():
+    '''Test the class ErrorXPathElementUnknown (unknown type of search result)'''
+    # Use an improper table name
+    test_result = {'test': 'dict'}
+    # Raise the error
+    test_error = NCBImetaErrors.ErrorXPathElementUnknown(test_result)
+    error_output = str(test_error)
+    error_expect =  ("\n\nUnknown XPath return element: {}".format(type(test_result)))
+    assert error_output == error_expect

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -123,3 +123,77 @@ def test_sql_sanitize():
     test_target_name = "droptables"
     test_sanitize_name = NCBImetaUtilities.sql_sanitize(test_name)
     assert test_target_name == test_sanitize_name
+
+def test_adv_xml_search_root():
+    '''Test the utility function adv_xml_search, navigating from root of document (use XPath query, PR #9)'''
+    test_xml = '''
+    <GBSeq_feature-table>
+        <GBFeature>
+            <GBFeature_key>source</GBFeature_key>
+            <GBFeature_quals>
+                <GBQualifier>
+                    <GBQualifier_name>organism</GBQualifier_name>
+                    <GBQualifier_value>my_name</GBQualifier_value>
+                </GBQualifier>
+            </GBFeature_quals>
+        </GBFeature>
+        <GBFeature>
+            <GBFeature_key>gene</GBFeature_key>
+            <GBFeature_quals>
+                <GBQualifier>
+                    <GBQualifier_name>gene</GBQualifier_name>
+                    <GBQualifier_value>my_gene_here</GBQualifier_value>
+                </GBQualifier>
+            </GBFeature_quals>
+        </GBFeature>
+    </GBSeq_feature-table>
+    '''
+    test_xml_root = etree.fromstring(test_xml)
+    test_payload = "XPATH, //GBSeq_feature-table/GBFeature[GBFeature_key/text() = 'source']/GBFeature_quals/GBQualifier[GBQualifier_name/text() = 'organism']/GBQualifier_value"
+    test_xpath = test_payload.split(", ")[1]
+    test_column_name = 'GBOrganismName'
+    test_xml_dict = {test_column_name : [] }
+    expect_xml_dict = {test_column_name : ['my_name'] }
+    NCBImetaUtilities.adv_xml_search(test_xml_root, test_xpath, test_column_name, test_xml_dict)
+    assert test_xml_dict == expect_xml_dict
+
+def test_adv_xml_search_tip():
+    '''Test the utility function adv_xml_search, navigating from tip of document (use XPath query, PR #9)'''
+    test_xml ='''
+    <User-object_data>
+        <User-field>
+            <User-field_label>
+                <Object-id>
+                    <Object-id_str>BioProject</Object-id_str>
+                </Object-id>
+            </User-field_label>
+            <User-field_num>1</User-field_num>
+                <User-field_data>
+                    <User-field_data_strs>
+                        <User-field_data_strs_E>PRJNA596632</User-field_data_strs_E>
+                    </User-field_data_strs>
+                </User-field_data>
+        </User-field>
+        <User-field>
+            <User-field_label>
+                <Object-id>
+                    <Object-id_str>BioSample</Object-id_str>
+                </Object-id>
+            </User-field_label>
+            <User-field_num>1</User-field_num>
+            <User-field_data>
+                <User-field_data_strs>
+                    <User-field_data_strs_E>SAMN13632826</User-field_data_strs_E>
+                </User-field_data_strs>
+            </User-field_data>
+        </User-field>
+    </User-object_data>
+    '''
+    test_xml_root = etree.fromstring(test_xml)
+    test_payload = "XPATH, //User-field_data_strs_E[../../../User-field_label/Object-id/Object-id_str/text() = 'BioSample']"
+    test_xpath = test_payload.split(", ")[1]
+    test_column_name = 'GBOrganismName'
+    test_xml_dict = {test_column_name : [] }
+    expect_xml_dict = {test_column_name : ['SAMN13632826'] }
+    NCBImetaUtilities.adv_xml_search(test_xml_root, test_xpath, test_column_name, test_xml_dict)
+    assert test_xml_dict == expect_xml_dict

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -182,7 +182,6 @@ def test_adv_xml_search_rel():
     </GBSeq_feature-table>
     '''
     test_xml_root = etree.fromstring(test_xml)
-    #test_payload = "XPATH, //User-field_data_strs_E[../../../User-field_label/Object-id/Object-id_str/text() = 'BioSample']"
     test_payload = "XPATH, //GBQualifier[GBQualifier_name/text() = 'organism']/GBQualifier_value"
     test_xpath = test_payload.split(", ")[1]
     test_column_name = 'GBOrganismName'
@@ -200,7 +199,6 @@ def test_adv_xml_search_attr():
     </Links>
     '''
     test_xml_root = etree.fromstring(test_xml)
-    #test_payload = "XPATH, //User-field_data_strs_E[../../../User-field_label/Object-id/Object-id_str/text() = 'BioSample']"
     test_payload = "XPATH, //Links/Link[@target='bioproject']/@label"
     test_xpath = test_payload.split(", ")[1]
     test_column_name = 'BioProject'

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -160,40 +160,23 @@ def test_adv_xml_search_root():
 def test_adv_xml_search_tip():
     '''Test the utility function adv_xml_search, navigating from tip of document (use XPath query, PR #9)'''
     test_xml ='''
-    <User-object_data>
-        <User-field>
-            <User-field_label>
-                <Object-id>
-                    <Object-id_str>BioProject</Object-id_str>
-                </Object-id>
-            </User-field_label>
-            <User-field_num>1</User-field_num>
-                <User-field_data>
-                    <User-field_data_strs>
-                        <User-field_data_strs_E>PRJNA596632</User-field_data_strs_E>
-                    </User-field_data_strs>
-                </User-field_data>
-        </User-field>
-        <User-field>
-            <User-field_label>
-                <Object-id>
-                    <Object-id_str>BioSample</Object-id_str>
-                </Object-id>
-            </User-field_label>
-            <User-field_num>1</User-field_num>
-            <User-field_data>
-                <User-field_data_strs>
-                    <User-field_data_strs_E>SAMN13632826</User-field_data_strs_E>
-                </User-field_data_strs>
-            </User-field_data>
-        </User-field>
-    </User-object_data>
+    <GBSeq_xrefs>
+      <GBXref>
+        <GBXref_dbname>BioProject</GBXref_dbname>
+        <GBXref_id>PRJNA412676</GBXref_id>
+      </GBXref>
+      <GBXref>
+        <GBXref_dbname>BioSample</GBXref_dbname>
+        <GBXref_id>SAMN07722868</GBXref_id>
+      </GBXref>
+    </GBSeq_xrefs>
     '''
     test_xml_root = etree.fromstring(test_xml)
-    test_payload = "XPATH, //User-field_data_strs_E[../../../User-field_label/Object-id/Object-id_str/text() = 'BioSample']"
+    #test_payload = "XPATH, //User-field_data_strs_E[../../../User-field_label/Object-id/Object-id_str/text() = 'BioSample']"
+    test_payload = "XPATH, //GBXref[GBXref_dbname/text() = 'BioSample']/GBXref_id"
     test_xpath = test_payload.split(", ")[1]
     test_column_name = 'GBOrganismName'
     test_xml_dict = {test_column_name : [] }
-    expect_xml_dict = {test_column_name : ['SAMN13632826'] }
+    expect_xml_dict = {test_column_name : ['SAMN07722868'] }
     NCBImetaUtilities.adv_xml_search(test_xml_root, test_xpath, test_column_name, test_xml_dict)
     assert test_xml_dict == expect_xml_dict

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -124,7 +124,7 @@ def test_sql_sanitize():
     test_sanitize_name = NCBImetaUtilities.sql_sanitize(test_name)
     assert test_target_name == test_sanitize_name
 
-def test_adv_xml_search_root():
+def test_adv_xml_search_abs():
     '''Test the utility function adv_xml_search, navigating from root of document (use XPath query, PR #9)'''
     test_xml = '''
     <GBSeq_feature-table>
@@ -157,26 +157,37 @@ def test_adv_xml_search_root():
     NCBImetaUtilities.adv_xml_search(test_xml_root, test_xpath, test_column_name, test_xml_dict)
     assert test_xml_dict == expect_xml_dict
 
-def test_adv_xml_search_tip():
+def test_adv_xml_search_rel():
     '''Test the utility function adv_xml_search, navigating from tip of document (use XPath query, PR #9)'''
     test_xml ='''
-    <GBSeq_xrefs>
-      <GBXref>
-        <GBXref_dbname>BioProject</GBXref_dbname>
-        <GBXref_id>PRJNA412676</GBXref_id>
-      </GBXref>
-      <GBXref>
-        <GBXref_dbname>BioSample</GBXref_dbname>
-        <GBXref_id>SAMN07722868</GBXref_id>
-      </GBXref>
-    </GBSeq_xrefs>
+    <GBSeq_feature-table>
+        <GBFeature>
+            <GBFeature_key>source</GBFeature_key>
+            <GBFeature_quals>
+                <GBQualifier>
+                    <GBQualifier_name>organism</GBQualifier_name>
+                    <GBQualifier_value>my_name</GBQualifier_value>
+                </GBQualifier>
+            </GBFeature_quals>
+        </GBFeature>
+        <GBFeature>
+            <GBFeature_key>gene</GBFeature_key>
+            <GBFeature_quals>
+                <GBQualifier>
+                    <GBQualifier_name>gene</GBQualifier_name>
+                    <GBQualifier_value>my_gene_here</GBQualifier_value>
+                </GBQualifier>
+            </GBFeature_quals>
+        </GBFeature>
+    </GBSeq_feature-table>
     '''
     test_xml_root = etree.fromstring(test_xml)
     #test_payload = "XPATH, //User-field_data_strs_E[../../../User-field_label/Object-id/Object-id_str/text() = 'BioSample']"
-    test_payload = "XPATH, //GBXref[GBXref_dbname/text() = 'BioSample']/GBXref_id"
+    test_payload = "XPATH, //GBQualifier[GBQualifier_name/text() = 'organism']/GBQualifier_value"
     test_xpath = test_payload.split(", ")[1]
     test_column_name = 'GBOrganismName'
     test_xml_dict = {test_column_name : [] }
-    expect_xml_dict = {test_column_name : ['SAMN07722868'] }
+    expect_xml_dict = {test_column_name : ['my_name'] }
     NCBImetaUtilities.adv_xml_search(test_xml_root, test_xpath, test_column_name, test_xml_dict)
+    print(test_xml_dict)
     assert test_xml_dict == expect_xml_dict

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -201,7 +201,7 @@ def test_adv_xml_search_attr():
     '''
     test_xml_root = etree.fromstring(test_xml)
     #test_payload = "XPATH, //User-field_data_strs_E[../../../User-field_label/Object-id/Object-id_str/text() = 'BioSample']"
-    test_payload = "XPATH, //Links/Link[@type='entrez']/@label"
+    test_payload = "XPATH, //Links/Link[@target='bioproject']/@label"
     test_xpath = test_payload.split(", ")[1]
     test_column_name = 'BioProject'
     test_xml_dict = {test_column_name : [] }

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -189,5 +189,23 @@ def test_adv_xml_search_rel():
     test_xml_dict = {test_column_name : [] }
     expect_xml_dict = {test_column_name : ['my_name'] }
     NCBImetaUtilities.adv_xml_search(test_xml_root, test_xpath, test_column_name, test_xml_dict)
+    assert test_xml_dict == expect_xml_dict
+
+def test_adv_xml_search_attr():
+    '''Test the utility function adv_xml_search, label conditional (use XPath query, PR #9)'''
+    test_xml ='''
+    <Links>
+      <Link type="url" label="GEO Sample GSM3995467">https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSM3995467</Link>
+      <Link type="entrez" target="bioproject" label="PRJNA558013">558013</Link>
+    </Links>
+    '''
+    test_xml_root = etree.fromstring(test_xml)
+    #test_payload = "XPATH, //User-field_data_strs_E[../../../User-field_label/Object-id/Object-id_str/text() = 'BioSample']"
+    test_payload = "XPATH, //Links/Link[@type='entrez']/@label"
+    test_xpath = test_payload.split(", ")[1]
+    test_column_name = 'BioProject'
+    test_xml_dict = {test_column_name : [] }
+    expect_xml_dict = {test_column_name : ['PRJNA558013'] }
+    NCBImetaUtilities.adv_xml_search(test_xml_root, test_xpath, test_column_name, test_xml_dict)
     print(test_xml_dict)
     assert test_xml_dict == expect_xml_dict


### PR DESCRIPTION
**This pull request continues implementation of XPath queries in the config.yaml file.**

There were a few edge cases that generated errors when using ```adv_xml_search```, for example, trying to fetch an attribute value rather than a text node. I've added a series of try/except statements to check what kind of node was returned. ```adv_xml_search``` was also modified to take direct Xpath queries, instead of friendly comma-separated input.

Three unit tests were added to ```test_utilities.py```:
```
test_adv_xml_search_abs()
test_adv_xml_search_rel()
test_adv_xml_search_attr()
```
XPath queries are included for two metadata fields in the example config.yaml:
```
- BioSampleBioProjectAccession: XPATH, //Links/Link[@target='bioproject']/@label
- NucleotideBioSampleAccession: XPATH, //GBXref[GBXref_dbname/text() = 'BioSample']/GBXref_id
```

These changes seem cover most of the use-cases/XML I'm encountering right now. I wonder though if you have alternative ideas for implementation, or additional cases to be considered?